### PR TITLE
OpenShift arbitrary uid support for apb-base

### DIFF
--- a/apb-base/Dockerfile
+++ b/apb-base/Dockerfile
@@ -3,8 +3,19 @@ MAINTAINER Ansible Playbook Bundle Community
 
 LABEL "com.redhat.apb.version"="0.1.0"
 
+ENV USER_NAME=apb \
+    USER_UID=1001 \
+    BASE_DIR=/opt/apb
+ENV HOME=${BASE_DIR}
+
 RUN mkdir -p /root/.kube /usr/share/ansible/openshift \
-            /etc/ansible /opt/apb /opt/ansible
+             /etc/ansible /opt/ansible \
+             ${BASE_DIR} ${BASE_DIR}/etc \
+             ${BASE_DIR}/.kube ${BASE_DIR}/.ansible/tmp && \
+             useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} && \
+             chown -R ${USER_NAME}:0 /opt/{ansible,apb} && \
+             chmod -R g+rw /opt/{ansible,apb} ${BASE_DIR} /etc/passwd
+
 COPY config /root/.kube/config
 RUN yum -y install epel-release centos-release-openshift-origin \
     && yum -y update \
@@ -22,7 +33,7 @@ RUN ansible-galaxy install ansible.kubernetes-modules
 
 COPY oc-login.sh entrypoint.sh /usr/bin/
 
-RUN useradd -u 1001 -r -g 0 -M -b /opt/apb -s /sbin/nologin -c "apb user" apb
-RUN chown -R apb: /opt/{ansible,apb}
 
+USER ${USER_UID}
+RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${BASE_DIR}/etc/passwd.template
 ENTRYPOINT ["entrypoint.sh"]

--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 ACTION=$1
+USER_ID=$(id -u)
 shift
 playbooks=/opt/apb/actions
 
+if [ ${USER_UID} != ${USER_ID} ]; then
+sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" ${BASE_DIR}/etc/passwd.template > /etc/passwd
+fi
 oc-login.sh
 
 if [[ -e "$playbooks/$ACTION.yaml" ]]; then


### PR DESCRIPTION
This PR adds the ability to run apb-base containers under OpenShift using the restricted scc and arbitrary uid support. These changes were based on previous work from:

- https://github.com/RHsyseng/container-rhel-examples/tree/master/starter-arbitrary-uid
- https://github.com/fusor/ansibleapp-library/pull/42

I used this [repository](https://github.com/jcpowermac/apbtest) to test with.  Very basic to confirm that ansible will run correctly.

### Before Changes using test repository
[![before changes](https://asciinema.org/a/120161.png)](https://asciinema.org/a/120161)

### After changes using test repository
[![with changes](https://asciinema.org/a/120179.png)](https://asciinema.org/a/120179)