### PR TITLE
Travis tests and base mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 group: deprecated-2017Q2
 
 env:
+  - VARIANT=apb-base TARGET=centos7
   - VARIANT=hello-world-apb TARGET=centos7
 #  - VARIANT=rhscl-postgresql-apb TARGET=centos7
 
@@ -25,7 +26,6 @@ before_script:
   - sudo mount --make-shared /
   - sudo service docker restart
 #  - make lint -C ${VARIANT}
-  - make -C apb-base TARGET=${TARGET}
 
 script:
   - make -C ${VARIANT} TARGET=${TARGET}
@@ -39,3 +39,4 @@ script:
   - export REGISTRY_IP=`oc get svc/docker-registry -o json -n default | jq -r '.spec.clusterIP'`
   - make openshift-test -C ${VARIANT} TARGET=${TARGET} REGISTRY=${REGISTRY_IP} OC_USER=${OC_USER} OC_PASS=${OC_PASS}
   - oc version
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: required
+dist: trusty
+group: deprecated-2017Q2
+
+env:
+  - VARIANT=hello-world-apb TARGET=centos7
+#  - VARIANT=rhscl-postgresql-apb TARGET=centos7
+
+services:
+ - docker
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y nodejs jq
+
+install:
+#  - npm install -g dockerfile_lint
+
+before_script:
+  - mkdir $HOME/bin
+  - export PATH=$PATH:$HOME/bin
+  - tmp=`mktemp`
+  - echo '{"insecure-registries":["172.30.0.0/16"]}' > ${tmp}
+  - sudo mv ${tmp} /etc/docker/daemon.json
+  - sudo mount --make-shared /
+  - sudo service docker restart
+#  - make lint -C ${VARIANT}
+  - make -C apb-base TARGET=${TARGET}
+
+script:
+  - make -C ${VARIANT} TARGET=${TARGET}
+#  - make test -C ${VARIANT} TARGET=${TARGET}
+  - wget `curl -s https://api.github.com/repos/openshift/origin/releases/latest | jq -r ".assets[] | select(.name | test(\"linux-64bit\")) | .browser_download_url" | grep -i client-tools`
+  - tar xvfz `ls openshift-origin-client-tools-*.tar.gz` --strip-components=1 -C $HOME/bin
+  - oc cluster up
+  - export OC_USER=`oc whoami` OC_PASS=`oc whoami -t`
+  - oc login -u system:admin
+  - oc rollout status -w dc/docker-registry -n default || oc rollout retry dc/docker-registry -n default && oc rollout status -w dc/docker-registry -n default
+  - export REGISTRY_IP=`oc get svc/docker-registry -o json -n default | jq -r '.spec.clusterIP'`
+  - make openshift-test -C ${VARIANT} TARGET=${TARGET} REGISTRY=${REGISTRY_IP} OC_USER=${OC_USER} OC_PASS=${OC_PASS}
+  - oc version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+DIRS = \
+apb-base \
+hello-world-apb
+
+# Allow user to pass in OS build options
+ifeq ($(TARGET),rhel7)
+	DFILE := Dockerfile.${TARGET}
+else
+	TARGET := centos7
+	DFILE := Dockerfile
+endif
+
+all: build
+build: 
+	@for d in ${DIRS}; do ${MAKE} -C $$d TARGET=${TARGET}; done
+
+lint:
+	@for d in ${DIRS}; do ${MAKE} lint -C $$d; done
+
+clean:
+	@for d in ${DIRS}; do ${MAKE} clean -C $$d; done

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # apb-examples
+[![Build Status](https://travis-ci.org/fusor/apb-examples.svg?branch=master)](https://travis-ci.org/fusor/apb-examples)
+
 A repository of example ansible-playbook bundles (APBs)
 
 # APB Documentation

--- a/apb-base/Dockerfile
+++ b/apb-base/Dockerfile
@@ -10,8 +10,7 @@ ENV HOME=${BASE_DIR}
 
 RUN curl https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansible-service-broker/repo/epel-7/group_ansible-service-broker-ansible-service-broker-epel-7.repo -o /etc/yum.repos.d/asb.repo
 RUN yum -y install epel-release centos-release-openshift-origin \
-    && yum -y update \
-    && yum -y install origin-clients python-openshift ansible ansible-kubernetes-modules apb-base-scripts \
+    && yum -y install --setopt=tsflags=nodocs origin-clients python-openshift ansible ansible-kubernetes-modules apb-base-scripts \
     && yum clean all
 
 RUN mkdir -p /usr/share/ansible/openshift \

--- a/apb-base/Makefile
+++ b/apb-base/Makefile
@@ -2,6 +2,9 @@ CONTEXT = ansibleplaybookbundle
 VERSION = v2.3
 IMAGE_NAME = apb-base
 TARGET = centos7
+REGISTRY = docker-registry.default.svc.cluster.local
+OC_USER = developer
+OC_PASS = developer
 
 # Allow user to pass in OS build options
 ifeq ($(TARGET),rhel7)
@@ -18,6 +21,21 @@ build:
 lint:
 	dockerfile_lint -f Dockerfile
 #	dockerfile_lint -f Dockerfile.rhel7
+
+openshift-test:
+	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
+	oc login -u ${OC_USER} -p ${OC_PASS}
+	oc new-project ${PROJ_RANDOM}
+	oc new-project ${APB_APP}
+	oc adm policy add-role-to-user admin system:serviceaccount:${PROJ_RANDOM}:default
+	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
+	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
+	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
+	oc project ${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} -- provision --extra-vars 'namespace=${APB_APP}'
+	oc rollout status -w dc/${IMAGE_NAME}
+	oc describe dc/${IMAGE_NAME}
+	oc logs -f dc/${IMAGE_NAME}
 
 clean:
 	rm -f build

--- a/apb-base/Makefile
+++ b/apb-base/Makefile
@@ -1,0 +1,23 @@
+CONTEXT = ansibleplaybookbundle
+VERSION = v2.3
+IMAGE_NAME = apb-base
+TARGET = centos7
+
+# Allow user to pass in OS build options
+ifeq ($(TARGET),rhel7)
+	DFILE := Dockerfile.${TARGET}
+else
+	DFILE := Dockerfile
+endif
+
+all: build
+build:
+	docker build --pull -t ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} -t ${CONTEXT}/${IMAGE_NAME} -f ${DFILE} .
+	@if docker images ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}; then touch build; fi
+
+lint:
+	dockerfile_lint -f Dockerfile
+#	dockerfile_lint -f Dockerfile.rhel7
+
+clean:
+	rm -f build

--- a/apb-base/Makefile
+++ b/apb-base/Makefile
@@ -26,13 +26,12 @@ openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
 	oc login -u ${OC_USER} -p ${OC_PASS}
 	oc new-project ${PROJ_RANDOM}
-	oc new-project ${APB_APP}
 	oc adm policy add-role-to-user admin system:serviceaccount:${PROJ_RANDOM}:default
 	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
 	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc project ${PROJ_RANDOM}
-	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} -- provision --extra-vars 'namespace=${APB_APP}'
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc rollout status -w dc/${IMAGE_NAME}
 	oc describe dc/${IMAGE_NAME}
 	oc logs -f dc/${IMAGE_NAME}

--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -5,7 +5,7 @@ shift
 playbooks=/opt/apb/actions
 
 if [ ${USER_UID} != ${USER_ID} ]; then
-sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" ${BASE_DIR}/etc/passwd.template > /etc/passwd
+  sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" ${BASE_DIR}/etc/passwd.template > /etc/passwd
 fi
 oc-login.sh
 

--- a/apb-base/oc-login.sh
+++ b/apb-base/oc-login.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
-if [[ -z "${OPENSHIFT_TARGET}" ]] || [[ -z "${OPENSHIFT_USER}" ]] || [[ -z "${OPENSHIFT_PASS}" ]]; then
+if [[ ! -z "${OPENSHIFT_TARGET}" ]] && [[ ! -z "${OPENSHIFT_TOKEN}" ]]; then
+  echo "Got OPENSHIFT token."
+  LOGIN_PARAMS="--insecure-skip-tls-verify=true --token=$OPENSHIFT_TOKEN"
+else if [[ -z "${OPENSHIFT_TARGET}" ]] || [[ -z "${OPENSHIFT_USER}" ]] || [[ -z "${OPENSHIFT_PASS}" ]]; then
   echo "Openshift cluster credentials not provided. Assuming the broker is running inside an Openshift cluster"
   echo "Attempting to login with a service account..."
-  oc login https://kubernetes.default \
-    --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-    --token $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+  OPENSHIFT_TARGET=https://kubernetes.default
+  LOGIN_PARAMS="--certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+    --token $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 else
   echo "Got OPENSHIFT credentials."
-  oc login $OPENSHIFT_TARGET --insecure-skip-tls-verify=true -u $OPENSHIFT_USER -p $OPENSHIFT_PASS
+  LOGIN_PARAMS="--insecure-skip-tls-verify=true -u $OPENSHIFT_USER -p $OPENSHIFT_PASS"
 fi
+fi
+
+oc login $OPENSHIFT_TARGET $LOGIN_PARAMS

--- a/hello-world-apb/Makefile
+++ b/hello-world-apb/Makefile
@@ -1,0 +1,52 @@
+CONTEXT = ansibleplaybookbundle
+VERSION = v0.1
+IMAGE_NAME = hello-world-apb
+TARGET = centos7
+REGISTRY = docker-registry.default.svc.cluster.local
+OC_USER = developer
+OC_PASS = developer
+APB_APP = hello-world
+
+# Allow user to pass in OS build options
+ifeq ($(TARGET),rhel7)
+	DFILE := Dockerfile.${TARGET}
+else
+	DFILE := Dockerfile
+endif
+
+all: build
+build:
+	docker build -t ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} -t ${CONTEXT}/${IMAGE_NAME} -f ${DFILE} .
+	@if docker images ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}; then touch build; fi
+
+lint:
+	dockerfile_lint -f Dockerfile
+#	dockerfile_lint -f Dockerfile.rhel7
+
+openshift-test:
+	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
+	oc login -u ${OC_USER} -p ${OC_PASS}
+	oc new-project ${PROJ_RANDOM}
+	oc new-project ${APB_APP}
+	oc adm policy add-role-to-user admin system:serviceaccount:${PROJ_RANDOM}:default
+	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
+	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
+	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
+	oc project ${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} -- provision --extra-vars 'namespace=${APB_APP}'
+	oc rollout status -w dc/${IMAGE_NAME}
+	oc describe dc/${IMAGE_NAME}
+	oc logs -f dc/${IMAGE_NAME}
+	oc project ${APB_APP}
+	oc rollout status -w dc/${APB_APP}
+	oc status
+	sleep 5
+	oc describe pod `oc get pod --template '{{(index .items 0).metadata.name }}'`
+	curl `oc get svc/${APB_APP} --template '{{.spec.clusterIP}}:{{index .spec.ports 0 "port"}}'`
+	oc exec `oc get pod --template '{{(index .items 0).metadata.name }}'` ps aux
+
+#run:
+#	docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}
+
+clean:
+	rm -f build

--- a/hello-world-apb/roles/provision-hello-world-apb/tasks/main.yml
+++ b/hello-world-apb/roles/provision-hello-world-apb/tasks/main.yml
@@ -43,7 +43,7 @@
       image: docker.io/ansibleplaybookbundle/hello-world:latest
       name: hello-world
       ports:
-      - container_port: 80
+      - container_port: 8080
         protocol: TCP
 
 
@@ -64,8 +64,8 @@
       service: hello-world
     ports:
       - name: web
-        port: 80
-        target_port: 80
+        port: 8080
+        target_port: 8080
 
 
 #############################################################################


### PR DESCRIPTION
 - travis test will spin up latest origin via 'oc cluster up' and test apb deployment... currently apb-base and hello-world only. uses default scc settings to ensure restricted deploy works.
 - added ability to login w/ token for manual tests
 - added makfiles for apb-base and hello-world
 - changed hello-world-apb to use port 8080 so restricted scc deploys function
 - TO-DO -> readme edits to include make instructions

Latest travis test -
https://travis-ci.org/tchughesiv/apb-examples/builds/245970013