### PR TITLE
Modify entrypoint.sh in apb-base to properly handle spaces/special chars

### DIFF
--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -10,9 +10,9 @@ fi
 oc-login.sh
 
 if [[ -e "$playbooks/$ACTION.yaml" ]]; then
-  ansible-playbook $playbooks/$ACTION.yaml $@
+  ansible-playbook $playbooks/$ACTION.yaml "$@"
 elif [[ -e "$playbooks/$ACTION.yml" ]]; then
-  ansible-playbook $playbooks/$ACTION.yml $@
+  ansible-playbook $playbooks/$ACTION.yml "$@"
 else
   echo "'$ACTION' NOT IMPLEMENTED" # TODO
 fi


### PR DESCRIPTION
During development of the CloudFormation based RDS APB, I found that parameters provided through the OpenShift Web UI would be broken up into multiple tokens on spaces and special characters. This change fixed my problem.

I have not tested this fix with other APB examples.