### PR TITLE
Improve bind output by returning a unique error code for operations

### DIFF
--- a/apb-base/broker-bind-creds
+++ b/apb-base/broker-bind-creds
@@ -2,9 +2,14 @@
 
 CREDS="/etc/apb/bind-creds"
 
+# Broker will pickup exit codes during retries
+#
+# Exit code 0 - Credentials found
+# Exit code 2 - Credentials not available
+#
 if [ ! -s $CREDS ]; then
     echo "Bind credentials not available."
-    exit 1
+    exit 2
 else
     cat $CREDS
     rm $CREDS

--- a/deprecated/postgresql-apb/roles/postgresql-apb-openshift/tasks/main.yml
+++ b/deprecated/postgresql-apb/roles/postgresql-apb-openshift/tasks/main.yml
@@ -88,5 +88,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="<BIND_CREDENTIALS>{{ encoded_bind_credentials.stdout }}</BIND_CREDENTIALS>"
+   content="{{ encoded_bind_credentials.stdout }}"
    dest=/etc/apb/bind-creds

--- a/deprecated/postgresql-demo-apb/roles/postgresql-demo-apb-openshift/tasks/main.yml
+++ b/deprecated/postgresql-demo-apb/roles/postgresql-demo-apb-openshift/tasks/main.yml
@@ -119,5 +119,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="<BIND_CREDENTIALS>{{ encoded_bind_credentials.stdout }}</BIND_CREDENTIALS>"
+   content="{{ encoded_bind_credentials.stdout }}"
    dest=/etc/apb/bind-creds

--- a/deprecated/pyzip-demo-db-apb/roles/provision-pyzip-demo-db-apb/tasks/main.yml
+++ b/deprecated/pyzip-demo-db-apb/roles/provision-pyzip-demo-db-apb/tasks/main.yml
@@ -118,5 +118,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="<BIND_CREDENTIALS>{{ encoded_bind_credentials.stdout }}</BIND_CREDENTIALS>"
+   content="{{ encoded_bind_credentials.stdout }}"
    dest=/etc/apb/bind-creds

--- a/deprecated/rds-postgres-apb/roles/rds-apb-openshift/tasks/main.yml
+++ b/deprecated/rds-postgres-apb/roles/rds-apb-openshift/tasks/main.yml
@@ -71,5 +71,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="<BIND_CREDENTIALS>{{ encoded_bind_credentials.stdout }}</BIND_CREDENTIALS>"
+   content="{{ encoded_bind_credentials.stdout }}"
    dest=/etc/apb/bind-creds

--- a/rhscl-postgresql-apb/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
+++ b/rhscl-postgresql-apb/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
@@ -114,5 +114,5 @@
   when: state == 'present'
 
 - copy:
-   content="<BIND_CREDENTIALS>{{ encoded_bind_credentials.stdout }}</BIND_CREDENTIALS>"
+   content="{{ encoded_bind_credentials.stdout }}"
    dest=/etc/apb/bind-creds


### PR DESCRIPTION
Use error code to signal the broker. Also remove <BIND_CREDENTIALS> tag.

Fixes https://github.com/fusor/apb-examples/issues/34
depends-on: https://github.com/openshift/ansible-service-broker/pull/276