### PR TITLE
add s2i assemple check in entrypoint.sh

### DIFF
--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+
+# Work-Around
+# The OpenShift's s2i (source to image) requires that no ENTRYPOINT exist
+# for any of the s2i builder base images.  Our 's2i-apb' builder uses the
+# apb-base as it's base image.  But since the apb-base defines its own
+# entrypoint.sh, it is not compatible with the current source-to-image.
+#
+# The below work-around checks if the entrypoint was called within the
+# s2i's 'assemble' script of if it was during a APB's run process.
+# If it's from an assemble process, it skips the APB's entrypoints procedures,
+# and vice versa.
+#
+# Details of the issue in the link below:
+# https://github.com/openshift/source-to-image/issues/475
+#
+if [[ $@ == *"s2i/assemble"* ]]; then
+  echo "---> Performing S2I build... Skipping server startup"
+  exec "$@"
+  exit $?
+fi
+
 ACTION=$1
 USER_ID=$(id -u)
 shift

--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -7,9 +7,8 @@
 # entrypoint.sh, it is not compatible with the current source-to-image.
 #
 # The below work-around checks if the entrypoint was called within the
-# s2i's 'assemble' script of if it was during a APB's run process.
-# If it's from an assemble process, it skips the APB's entrypoints procedures,
-# and vice versa.
+# s2i-apb's 'assemble' script process. If so, it skips the rest of the steps
+# which are APB run-time specific.
 #
 # Details of the issue in the link below:
 # https://github.com/openshift/source-to-image/issues/475


### PR DESCRIPTION
this work around in the 'entrypoint.sh' is currently required to make APB images built with [s2i-apb](https://github.com/fusor/s2i-apb) to be executed properly within OpenShift. 

Issue regarding ENTRYPOINT for s2i:
https://github.com/openshift/source-to-image/issues/475