### PR TITLE
Use a writable destination to store the temporary credentials file

### DIFF
--- a/apb-base/Dockerfile
+++ b/apb-base/Dockerfile
@@ -14,13 +14,11 @@ RUN yum -y install epel-release centos-release-openshift-origin \
     && yum clean all
 
 RUN mkdir -p /usr/share/ansible/openshift \
-             /etc/apb \
              /etc/ansible /opt/ansible \
              ${BASE_DIR} ${BASE_DIR}/etc \
              ${BASE_DIR}/.kube ${BASE_DIR}/.ansible/tmp && \
              useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} && \
              chown -R ${USER_NAME}:0 /opt/{ansible,apb} && \
-             chown -R ${USER_NAME}:0 /etc/apb && \
              chmod -R g+rw /opt/{ansible,apb} ${BASE_DIR} /etc/passwd
 
 RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/apb-base/Dockerfile-src
+++ b/apb-base/Dockerfile-src
@@ -4,8 +4,7 @@ MAINTAINER Ansible Playbook Bundle Community
 LABEL "com.redhat.apb.version"="0.1.0"
 
 RUN mkdir -p /usr/share/ansible/openshift \
-             /etc/ansible /opt/apb /opt/ansible \
-             /etc/apb
+             /etc/ansible /opt/apb /opt/ansible
 
 RUN yum -y install epel-release centos-release-openshift-origin \
     && yum -y update \
@@ -34,7 +33,6 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
 COPY oc-login.sh entrypoint.sh broker-bind-creds bind-init /usr/bin/
 
 RUN useradd -u 1001 -r -g 0 -M -b /opt/apb -s /sbin/nologin -c "apb user" apb
-RUN chown -R apb: /opt/{ansible,apb} && \
-    chown -R apb: /etc/apb
+RUN chown -R apb: /opt/{ansible,apb}
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/apb-base/bind-init
+++ b/apb-base/bind-init
@@ -2,7 +2,7 @@
 
 # Pod will stay up for 5 minutes
 RETRIES=150
-CREDS="/etc/apb/bind-creds"
+CREDS="/var/tmp/bind-creds"
 
 for r in $(seq 1 $RETRIES); do
     if [ -f $CREDS ]; then

--- a/apb-base/broker-bind-creds
+++ b/apb-base/broker-bind-creds
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CREDS="/etc/apb/bind-creds"
+CREDS="/var/tmp/bind-creds"
 
 # Broker will pickup exit codes during retries
 #

--- a/apb-base/entrypoint.sh
+++ b/apb-base/entrypoint.sh
@@ -23,7 +23,7 @@ ACTION=$1
 USER_ID=$(id -u)
 shift
 playbooks=/opt/apb/actions
-CREDS="/etc/apb/bind-creds"
+CREDS="/var/tmp/bind-creds"
 
 set -x
 

--- a/deprecated/postgresql-apb/roles/postgresql-apb-openshift/tasks/main.yml
+++ b/deprecated/postgresql-apb/roles/postgresql-apb-openshift/tasks/main.yml
@@ -88,5 +88,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="{{ encoded_bind_credentials.stdout }}"
-   dest=/etc/apb/bind-creds
+    content: "{{ encoded_bind_credentials.stdout }}"
+    dest: /var/tmp/bind-creds

--- a/deprecated/postgresql-demo-apb/roles/postgresql-demo-apb-openshift/tasks/main.yml
+++ b/deprecated/postgresql-demo-apb/roles/postgresql-demo-apb-openshift/tasks/main.yml
@@ -119,5 +119,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="{{ encoded_bind_credentials.stdout }}"
-   dest=/etc/apb/bind-creds
+    content: "{{ encoded_bind_credentials.stdout }}"
+    dest: /var/tmp/bind-creds

--- a/deprecated/pyzip-demo-db-apb/roles/provision-pyzip-demo-db-apb/tasks/main.yml
+++ b/deprecated/pyzip-demo-db-apb/roles/provision-pyzip-demo-db-apb/tasks/main.yml
@@ -118,5 +118,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="{{ encoded_bind_credentials.stdout }}"
-   dest=/etc/apb/bind-creds
+    content: "{{ encoded_bind_credentials.stdout }}"
+    dest: /var/tmp/bind-creds

--- a/deprecated/rds-postgres-apb/roles/rds-apb-openshift/tasks/main.yml
+++ b/deprecated/rds-postgres-apb/roles/rds-apb-openshift/tasks/main.yml
@@ -71,5 +71,5 @@
   register: encoded_bind_credentials
 
 - copy:
-   content="{{ encoded_bind_credentials.stdout }}"
-   dest=/etc/apb/bind-creds
+    content: "{{ encoded_bind_credentials.stdout }}"
+    dest: /var/tmp/bind-creds

--- a/rhscl-postgresql-apb/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
+++ b/rhscl-postgresql-apb/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
@@ -114,5 +114,5 @@
   when: state == 'present'
 
 - copy:
-   content="{{ encoded_bind_credentials.stdout }}"
-   dest=/etc/apb/bind-creds
+    content: "{{ encoded_bind_credentials.stdout }}"
+    dest: /var/tmp/bind-creds


### PR DESCRIPTION
When running under an arbitrary UID (e.g. under the default restricted OpenShift SCC) we can't write to `/etc/apb`, so we get failures like:

```
TASK [rhscl-postgresql-apb-openshift : copy] ***********************************
fatal: [localhost]: FAILED! => {"changed": false, "checksum": "e3a28f79922c1e4525d97519c2e7209584d45e29", "failed": true, "msg": "Destination /etc/apb not writable"}
```

A suggestion is to use `/var/tmp` instead of `/etc/apb` as a place to store the temporary credentials file.

Alternatively we could [ab]use the group ID and make `/etc/apb` writable, but `/var/tmp` sounds like a better place for temporary data anyway and doesn't need special tweaks.