### PR TITLE
Jenkins - BuildConfig module issues

### DIFF
--- a/jenkins-apb/roles/provision-jenkins-apb/tasks/main.yml
+++ b/jenkins-apb/roles/provision-jenkins-apb/tasks/main.yml
@@ -132,23 +132,18 @@
         source_git_ref is defined and
         source_context_dir is defined
 
+- name: Template - Create BuildConfig
+  template:
+    src: buildconfig.yaml.j2
+    dest: /tmp/buildconfig.yaml
+  register: buildconfig
+  when: source_git_uri is defined and
+        source_git_ref is defined and
+        source_context_dir is defined
+
 - name: Create BuildConfig
-  openshift_v1_build_config:
-    name: "{{ jenkins_service_name }}"
-    namespace: "{{ namespace }}"
-    spec_output_to_kind: "ImageStreamTag"
-    spec_output_to_name: "jenkins:latest"
-    spec_source_context_dir: "{{ source_context_dir }}"
-    spec_source_git_uri: "{{ source_git_uri }}"
-    spec_source_git_ref: "{{ source_git_ref }}"
-    spec_source_type: "Git"
-    spec_strategy_source_strategy__from_kind: "ImageStreamTag"
-    spec_strategy_source_strategy__from_name: "jenkins:2"
-    spec_strategy_source_strategy__from_namespace: "openshift"
-    spec_triggers:
-      - type: ConfigChange
-      - type: ImageChange
-    state: "{{ state }}"
+  command: "oc create -f {{ buildconfig.dest | default(buildconfig.path) }} -n {{ namespace }}"
+  ignore_errors: True
   when: source_git_uri is defined and
         source_git_ref is defined and
         source_context_dir is defined

--- a/jenkins-apb/roles/provision-jenkins-apb/templates/buildconfig.yaml.j2
+++ b/jenkins-apb/roles/provision-jenkins-apb/templates/buildconfig.yaml.j2
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: "{{ jenkins_service_name }}"
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: jenkins:latest
+  source:
+    contextDir: "{{ source_context_dir }}"
+    git:
+      uri: "{{ source_git_uri }}"
+      ref: "{{ source_git_ref }}"
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: jenkins:2
+        namespace: openshift
+    type: Source
+  triggers:
+  - type: ConfigChange
+  - imageChange: {}
+    type: ImageChange


### PR DESCRIPTION
When testing this APB I used my locally installed openshift python
library and ansible kube modules.  In this scenario the
`openshift_v1_build_config` module functioned correctly.
For some reason when using apb-base that module fails.

See: https://github.com/openshift/openshift-restclient-python/issues/75

This PR reverts to using `oc create -f` and ansible template.