### PR TITLE
travis-ci & arb-uid updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 dist: trusty
-group: deprecated-2017Q2
 
 env:
   - VARIANT=apb-base TARGET=centos7
@@ -20,7 +19,6 @@ install:
 #  - if [ ${BUILD} ]; then make lint -C ${VARIANT}; fi
 
 before_script:
-  - if [ ${BUILD} ]; then mkdir $HOME/bin; fi
   - if [ ${BUILD} ]; then export PATH=$PATH:$HOME/bin; fi
   - if [ ${BUILD} ]; then tmp=`mktemp`; fi
   - if [ ${BUILD} ]; then echo '{"insecure-registries":["172.30.0.0/16"]}' > ${tmp}; fi
@@ -33,7 +31,7 @@ script:
 #  - if [ ${BUILD} ]; then make test -C ${VARIANT} TARGET=${TARGET}; fi
   - if [ ${BUILD} ]; then wget `curl -s https://api.github.com/repos/openshift/origin/releases/latest | jq -r ".assets[] | select(.name | test(\"linux-64bit\")) | .browser_download_url" | grep -i client-tools`; fi
   - if [ ${BUILD} ]; then tar xvfz `ls openshift-origin-client-tools-*.tar.gz` --strip-components=1 -C $HOME/bin; fi
-  - if [ ${BUILD} ]; then oc cluster up; fi
+  - if [ ${BUILD} ]; then if [ ${OCP_VERSION} ]; then oc cluster up --version=${OCP_VERSION}; else oc cluster up; fi; fi
   - if [ ${BUILD} ]; then export OC_USER=`oc whoami` OC_PASS=`oc whoami -t`; fi
   - if [ ${BUILD} ]; then oc login -u system:admin; fi
   - if [ ${BUILD} ]; then oc rollout status -w dc/docker-registry -n default || oc rollout retry dc/docker-registry -n default && oc rollout status -w dc/docker-registry -n default; fi

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ LABEL "com.redhat.apb.spec"="some-long-blob-value"
 
 ADD playbooks /opt/apb/actions
 ADD roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb
 ```

--- a/apb-base/Dockerfile
+++ b/apb-base/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/share/ansible/openshift \
              ${BASE_DIR}/{etc,.kube,.ansible/tmp} \
              && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} \
              && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
-             && chmod -R g=u /opt/{ansible,apb} ${BASE_DIR} /etc/passwd
+             && chmod -R g=u /opt/{ansible,apb} /etc/passwd
 
 COPY files/etc/ansible/* /etc/ansible/
 COPY files/usr/bin/* /usr/bin/

--- a/apb-base/Dockerfile
+++ b/apb-base/Dockerfile
@@ -23,5 +23,4 @@ RUN mkdir -p /usr/share/ansible/openshift \
 COPY files/etc/ansible/* /etc/ansible/
 COPY files/usr/bin/* /usr/bin/
 
-RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > /etc/passwd.template
 ENTRYPOINT ["entrypoint.sh"]

--- a/apb-base/files/usr/bin/entrypoint.sh
+++ b/apb-base/files/usr/bin/entrypoint.sh
@@ -28,9 +28,9 @@ CREDS="/var/tmp/bind-creds"
 
 set -x
 
-if [ -w /etc/passwd ]; then
-  if ! whoami &> /dev/null; then
-    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:$(id -u):@g" /etc/passwd.template > /etc/passwd
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-apb}:x:$(id -u):0:${USER_NAME:-apb} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 oc-login.sh

--- a/apb-base/files/usr/bin/entrypoint.sh
+++ b/apb-base/files/usr/bin/entrypoint.sh
@@ -26,8 +26,6 @@ shift
 playbooks=/opt/apb/actions
 CREDS="/var/tmp/bind-creds"
 
-set -x
-
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
     echo "${USER_NAME:-apb}:x:$(id -u):0:${USER_NAME:-apb} user:${HOME}:/sbin/nologin" >> /etc/passwd

--- a/deprecated/manageiq-apb/Dockerfile
+++ b/deprecated/manageiq-apb/Dockerfile
@@ -45,7 +45,6 @@ cyBzdWNoIGFzIHZpcnR1YWwgbWFjaGluZXMsIHB1YmxpYyBjbG91ZHMgYW5kIGNvbnRhaW5lcnMu\
 Igo="
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/deprecated/postgresql-apb/Dockerfile
+++ b/deprecated/postgresql-apb/Dockerfile
@@ -23,7 +23,6 @@ cmluZwogICAgZGVmYXVsdDogYWRtaW4K"
 
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/deprecated/postgresql-demo-apb/Dockerfile
+++ b/deprecated/postgresql-demo-apb/Dockerfile
@@ -23,10 +23,9 @@ YXVsdDogYWRtaW4K"
 
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
 
 RUN yum install -y postgresql && yum clean all
 RUN pip install urllib3 boto
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/deprecated/rds-postgres-apb/Dockerfile
+++ b/deprecated/rds-postgres-apb/Dockerfile
@@ -53,8 +53,7 @@ MTdkZW1vL0RhdGFiYXNlX0FtYXpvblJEU19Qb3N0Z3JlU1FMaW5zdGFuY2UucG5nIgogIGRvY3Vt\
 ZW50YXRpb25Vcmw6ICJodHRwczovL2F3cy5hbWF6b24uY29tL3Jkcy8iCg=="
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 RUN yum -y install python-boto postgresql && yum clean all
 

--- a/etherpad-apb/Dockerfile
+++ b/etherpad-apb/Dockerfile
@@ -31,7 +31,6 @@ ICAgIHRpdGxlOiBSb290IFBhc3N3b3JkCg=="
 
 ADD playbooks /opt/apb/actions
 ADD roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/hello-world-apb/Dockerfile
+++ b/hello-world-apb/Dockerfile
@@ -16,7 +16,6 @@ b3JsZAogICAgICBjb3N0OiAkMC4wMAogICAgcGFyYW1ldGVyczogW10K"
 
 ADD playbooks /opt/apb/actions
 ADD roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/hello-world-apb/Makefile
+++ b/hello-world-apb/Makefile
@@ -32,7 +32,7 @@ openshift-test:
 	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc create sa apb
 	oc adm policy add-role-to-user admin -z apb
-	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"apb"}}' -- provision -e namespace=${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --as=apb -- provision -e namespace=${PROJ_RANDOM}
 	oc rollout status -w dc/${APB_APP}
 	oc status
 	sleep 5

--- a/hello-world-apb/Makefile
+++ b/hello-world-apb/Makefile
@@ -32,7 +32,7 @@ openshift-test:
 	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc create sa apb
 	oc adm policy add-role-to-user admin -z apb
-	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --as=apb -- provision -e namespace=${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"apb"}}' -- provision -e namespace=${PROJ_RANDOM}
 	oc rollout status -w dc/${APB_APP}
 	oc status
 	sleep 5

--- a/hello-world-apb/Makefile
+++ b/hello-world-apb/Makefile
@@ -25,7 +25,7 @@ lint:
 
 openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
-	oc login -u ${OC_USER} -p ${OC_PASS}
+	oc login --token=${OC_PASS}
 	oc new-project ${PROJ_RANDOM}
 	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
 	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}

--- a/jenkins-apb/Dockerfile
+++ b/jenkins-apb/Dockerfile
@@ -38,7 +38,6 @@ Kl9wCg=="
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/jenkins-apb/Makefile
+++ b/jenkins-apb/Makefile
@@ -32,7 +32,7 @@ openshift-test:
 	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc create sa apb
 	oc adm policy add-role-to-user admin -z apb
-	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"apb"}}' -- provision -e namespace=${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --as=apb -- provision -e namespace=${PROJ_RANDOM}
 	oc rollout status -w dc/${APB_APP}
 	oc status
 	sleep 5

--- a/jenkins-apb/Makefile
+++ b/jenkins-apb/Makefile
@@ -32,7 +32,7 @@ openshift-test:
 	docker push ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}
 	oc create sa apb
 	oc adm policy add-role-to-user admin -z apb
-	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --as=apb -- provision -e namespace=${PROJ_RANDOM}
+	oc run ${IMAGE_NAME} --image=${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME} --restart=Never --attach=true --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"apb"}}' -- provision -e namespace=${PROJ_RANDOM}
 	oc rollout status -w dc/${APB_APP}
 	oc status
 	sleep 5

--- a/jenkins-apb/Makefile
+++ b/jenkins-apb/Makefile
@@ -25,7 +25,7 @@ lint:
 
 openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
-	oc login -u ${OC_USER} -p ${OC_PASS}
+	oc login --token=${OC_PASS}
 	oc new-project ${PROJ_RANDOM}
 	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
 	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/${PROJ_RANDOM}/${IMAGE_NAME}

--- a/mediawiki123-apb/Dockerfile-dev
+++ b/mediawiki123-apb/Dockerfile-dev
@@ -25,7 +25,6 @@ cwo="
 
 ADD playbooks /opt/apb/actions
 ADD roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/pyzip-demo-apb/Dockerfile
+++ b/pyzip-demo-apb/Dockerfile
@@ -18,7 +18,6 @@ ICQwLjAwCiAgICBwYXJhbWV0ZXJzOiBbXQo="
 
 ADD playbooks /opt/apb/actions
 ADD roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/pyzip-demo-db-apb/Dockerfile
+++ b/pyzip-demo-db-apb/Dockerfile
@@ -27,8 +27,7 @@ MwogICAgICAgIHJlcXVpcmVkOiBUcnVlCg=="
 
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 RUN yum install -y postgresql && yum clean all
 

--- a/rhscl-mariadb-apb/Dockerfile
+++ b/rhscl-mariadb-apb/Dockerfile
@@ -32,7 +32,6 @@ X3VzZXIKICAK"
 
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/rhscl-postgresql-apb/Dockerfile-dev
+++ b/rhscl-postgresql-apb/Dockerfile-dev
@@ -38,7 +38,6 @@ ICAgIGNvc3Q6ICQ1Ljk5IG1vbnRobHkKICAgIHBhcmFtZXRlcnM6ICpfcAo="
 
 COPY roles /opt/ansible/roles
 COPY playbooks/* /opt/apb/actions/
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb

--- a/rocketchat-apb/dockerhub/Dockerfile
+++ b/rocketchat-apb/dockerhub/Dockerfile
@@ -34,6 +34,6 @@ IFZlcnNpb24KICAgICAgICByZXF1aXJlZDogVHJ1ZQo="
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
+
 USER apb

--- a/rocketchat-apb/rhcc/Dockerfile
+++ b/rocketchat-apb/rhcc/Dockerfile
@@ -35,6 +35,6 @@ OiBSb2NrZXRDaGF0IFZlcnNpb24KICAgICAgICByZXF1aXJlZDogVHJ1ZQo="
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
+
 USER apb

--- a/wordpress-ha-apb/Dockerfile
+++ b/wordpress-ha-apb/Dockerfile
@@ -36,7 +36,6 @@ bnQKICAgICAgICB0aXRsZTogbWF4aW11bSB3b3JkcHJlc3MgcmVwbGljYXMKICAgICAgICByZXF1\
 aXJlZDogVHJ1ZQo="
 COPY roles /opt/ansible/roles
 COPY playbooks /opt/apb/actions
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 
 USER apb


### PR DESCRIPTION
 - switch to latest travis-ci trusty distro
 - add optional OCP_VERSION flag for specifying openshift version for each VARIANT
 - switch to --token login for openshift-test(s)
 - new arb-uid method of simply appending passwd entry, rather than find/replace from a template.
    - simplifies apb-base Dockerfile
 - simplify perm commands in apb Dockerfiles also

perm mods reflected in this PR as well:
https://github.com/fusor/ansible-playbook-bundle/pull/83/files