### PR TITLE
Remove confusing error from apb logs

### DIFF
--- a/apb-base/files/usr/bin/entrypoint.sh
+++ b/apb-base/files/usr/bin/entrypoint.sh
@@ -33,18 +33,21 @@ if ! whoami &> /dev/null; then
 fi
 oc-login.sh
 
-if [[ -e "$playbooks/$ACTION.yaml" || -e "$playbooks/$ACTION.yml" ]]; then
-  ansible-playbook $playbooks/$ACTION.yml "$@" || ansible-playbook $playbooks/$ACTION.yaml "$@"
-
-  # If we are provisioning an APB, but it's not bindable then the bind-creds
-  # will never be created. Therefore, if bind-creds exists, we are running
-  # either provision or bind and the APB is bindable.
-  #
-  # bind-init keeps the container running until the broker gathers the bind
-  # credentials by exec'ing into the container.
-  if [ -f $CREDS ]; then
-     bind-init
-  fi
+if [[ -e "$playbooks/$ACTION.yaml" ]]; then
+  ansible-playbook $playbooks/$ACTION.yaml "$@"
+elif [[ -e "$playbooks/$ACTION.yml" ]]; then
+  ansible-playbook $playbooks/$ACTION.yml "$@"
 else
   echo "'$ACTION' NOT IMPLEMENTED" # TODO
+  exit 0
+fi
+
+# If we are provisioning an APB, but it's not bindable then the bind-creds
+# will never be created. Therefore, if bind-creds exists, we are running
+# either provision or bind and the APB is bindable.
+#
+# bind-init keeps the container running until the broker gathers the bind
+# credentials by exec'ing into the container.
+if [ -f $CREDS ]; then
+   bind-init
 fi


### PR DESCRIPTION
The error below was observed when provisioning an apb which led to confusion about what was going wrong:

```
+ [[ -e /opt/apb/actions/provision.yaml ]]
+ ansible-playbook /opt/apb/actions/provision.yml --extra-vars '{"_apb_plan_id":"dev","namespace":"ansible-service-broker","postgresql_database":"admin","postgresql_user":"admin","postgresql_version":"9.5"}'
ERROR! the playbook: /opt/apb/actions/provision.yml could not be found
+ ansible-playbook /opt/apb/actions/provision.yaml --extra-vars '{"_apb_plan_id":"dev","namespace":"ansible-service-broker","postgresql_database":"admin","postgresql_user":"admin","postgresql_version":"9.5"}'
```