### PR TITLE
Update apb-base to support passing mounted secrets to ansible

### DIFF
--- a/apb-base/Dockerfile-canary
+++ b/apb-base/Dockerfile-canary
@@ -50,18 +50,15 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
     && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
 
-RUN ansible-galaxy install ansible.kubernetes-modules git+https://github.com/fusor/ansible-asb-modules.git \
-    && mv /opt/ansible/roles/ansible-asb-modules /opt/ansible/roles/ansibleplaybookbundle.asb-modules
-
 COPY files/etc/ansible/* /etc/ansible/
 COPY files/usr/bin/* /usr/bin/
 
 RUN mkdir -p /usr/share/ansible/openshift \
-             /etc/ansible /opt/ansible \
-             ${BASE_DIR}/{etc,.kube,.ansible/tmp} \
-             && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} \
-             && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
-             && chmod -R g=u /opt/{ansible,apb} /etc/passwd
+              /etc/ansible /opt/ansible \
+              ${BASE_DIR}/{etc,.kube,.ansible/tmp} \
+              && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} \
+              && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
+              && chmod -R g=u /opt/{ansible,apb} /etc/passwd
 
 RUN mkdir /etc/apb-secrets
 

--- a/apb-base/Dockerfile-canary
+++ b/apb-base/Dockerfile-canary
@@ -50,15 +50,19 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
     && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
 
+RUN ansible-galaxy install ansible.kubernetes-modules git+https://github.com/fusor/ansible-asb-modules.git \
+    && mv /opt/ansible/roles/ansible-asb-modules /opt/ansible/roles/ansibleplaybookbundle.asb-modules
+
 COPY files/etc/ansible/* /etc/ansible/
 COPY files/usr/bin/* /usr/bin/
 
- RUN mkdir -p /usr/share/ansible/openshift \
-              /etc/ansible /opt/ansible \
-              ${BASE_DIR}/{etc,.kube,.ansible/tmp} \
-              && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} \
-              && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
-              && chmod -R g=u /opt/{ansible,apb} /etc/passwd
+RUN mkdir -p /usr/share/ansible/openshift \
+             /etc/ansible /opt/ansible \
+             ${BASE_DIR}/{etc,.kube,.ansible/tmp} \
+             && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "apb user" ${USER_NAME} \
+             && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
+             && chmod -R g=u /opt/{ansible,apb} /etc/passwd
 
+RUN mkdir /etc/apb-secrets
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Apb base will now add all secrets in /etc/apb-secrets to a temporary yaml file and pass that file into ansible-playbook

https://trello.com/c/oPvl3Rdy
Related:
https://github.com/openshift/ansible-service-broker/pull/345